### PR TITLE
Added foundation for multiple choice REDCap questions in DDP

### DIFF
--- a/app/DataRetrieval/DataGateway.php
+++ b/app/DataRetrieval/DataGateway.php
@@ -11,6 +11,7 @@ use App\FieldSource;
 use App\ProjectMetadata;
 use App\WebserviceSource;
 use phpDocumentor\Reflection\Project;
+use Illuminate\Support\Arr;
 
 class DataGateway implements DataGatewayInterface
 {
@@ -52,15 +53,25 @@ class DataGateway implements DataGatewayInterface
 
             $columnName = $metadata->fieldSource->column;
             $fieldName = $metadata->field;
-
-            $tmpResults = ['field' => $fieldName, 'value' => $row->$columnName];
+            $valueMappings = $metadata->fieldSource->valueMappings;
+            $fieldSourceValue = $row->$columnName;
+            $tmpResults = ['field' => $fieldName, 'value' => $fieldSourceValue];
+            
+            if(!$valueMappings->isEmpty()){
+                foreach($valueMappings as $mapping){
+                    if($mapping->field_source_value == $fieldSourceValue){
+                        $tmpResults['value'] = $mapping->redcap_value;
+                        break;
+                    }
+                }
+            }
 
             if($metadata->temporal) {
                 $anchor_date = $metadata->fieldSource->anchor_date;
 
                 array_push($tmpResults, ['timestamp' => $row->$anchor_date]);
             }
-
+            
             return $tmpResults;
         });
 

--- a/app/FieldSource.php
+++ b/app/FieldSource.php
@@ -27,4 +27,8 @@ class FieldSource extends Model
         return $this->belongsTo(DataSource::class);
     }
 
+    public function valueMappings()
+    {
+    	return $this->hasMany(ValueMapping::class);
+    }
 }

--- a/app/ValueMapping.php
+++ b/app/ValueMapping.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ValueMapping extends Model
+{
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * The field source this value mapping is for.
+     */
+    public function fieldSource()
+    {
+        return $this->belongsTo(FieldSource::class);
+    }
+}

--- a/database/factories/ValueMappingFactory.php
+++ b/database/factories/ValueMappingFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+/* @var $factory \Illuminate\Database\Eloquent\Factory */
+
+use App\DatabaseSource;
+use App\DatabaseType;
+use App\FieldSource;
+use App\ProjectMetadata;
+use App\ValueMapping;
+use Faker\Generator as Faker;
+
+$factory->define(ValueMapping::class, function (Faker $faker) {
+    return [
+        'field_source_value' => 'M',
+        'redcap_value' => '1'
+    ];
+});
+
+$factory->state(ValueMapping::class, 'with_source', function (\Faker\Generator $faker) {
+    return [
+        'field_source_id' => factory(FieldSource::class)->state('with_source')->create()->id
+    ];
+});

--- a/database/migrations/2019_12_27_173506_create_value_mappings_table.php
+++ b/database/migrations/2019_12_27_173506_create_value_mappings_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateValueMappingsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('value_mappings', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('field_source_value');
+            $table->string('redcap_value');
+            $table->timestamps();
+            $table->unsignedBigInteger('field_source_id');
+            $table->foreign('field_source_id')->references('id')->on('field_sources');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('value_mappings');
+    }
+}


### PR DESCRIPTION
Added value_mappings table, which maps a value coming from a data source to the value expected by REDCap. This allows us to populate multiple choice fields in DDP. For example, a "Gender" field may have values "M" or "F" in the field source, but REDCap expects either "1" or "2", which are codings for 2 radio buttons "Male" and "Female." If the appropriate value_mappings are set up then "M" in the field source will return "1" to REDCap, and "F" will return "2". I also added a unit test for a field with value mappings.