### PR TITLE
Trims whitespace for comparing value mappings of DDP results

### DIFF
--- a/app/DataRetrieval/DataGateway.php
+++ b/app/DataRetrieval/DataGateway.php
@@ -59,7 +59,7 @@ class DataGateway implements DataGatewayInterface
             
             if(!$valueMappings->isEmpty()){
                 foreach($valueMappings as $mapping){
-                    if($mapping->field_source_value == $fieldSourceValue){
+                    if($mapping->field_source_value == trim($fieldSourceValue)){
                         $tmpResults['value'] = $mapping->redcap_value;
                         break;
                     }


### PR DESCRIPTION
Trim whitespace when comparing the value from the field source to the mapped value