### PR TITLE
Use parameter binding instead of raw SQL

### DIFF
--- a/app/DataRetrieval/Database/DatabaseConnectionBase.php
+++ b/app/DataRetrieval/Database/DatabaseConnectionBase.php
@@ -29,7 +29,7 @@ abstract class DatabaseConnectionBase implements DatabaseConnection
     public function executeQuery($id)
     {
         try {
-            return DB::connection($this->dbSource->dataSource->name)->select($this->fieldsource->getQueryFor($id));
+            return DB::connection($this->dbSource->dataSource->name)->select($this->fieldsource->getQuery(), [$id]);
         } catch (\Exception $e)
         {
             Log::error($e->getMessage());

--- a/app/FieldSource.php
+++ b/app/FieldSource.php
@@ -9,13 +9,9 @@ use Illuminate\Support\Str;
 class FieldSource extends Model
 {
 
-    public function getQueryFor($id)
+    public function getQuery()
     {
-
-        $replaced = Str::replaceLast('= id', "= {$id}", $this->query);
-        $replaced = Str::replaceLast('= sid', "= '{$id}'", $replaced);
-
-        return $replaced;
+        return $this->query;
     }
 
     /**

--- a/tests/Unit/FieldSourceTest.php
+++ b/tests/Unit/FieldSourceTest.php
@@ -8,30 +8,17 @@ use Tests\TestCase;
 class FieldSourceTest extends TestCase
 {
     /** @test */
-    public function it_can_substitute_an_integer_identifier_in_a_query()
+    public function it_can_return_a_sql_query()
     {
         $fieldSource = factory(FieldSource::class)->make([
-            'query' => "SELECT gender from PATIENT where id = id"
+            'query' => "SELECT gender from PATIENT where id = ?"
         ]);
 
         $this->assertEquals(
-            "SELECT gender from PATIENT where id = 1",
-            $fieldSource->getQueryFor(1)
+            "SELECT gender from PATIENT where id = ?",
+            $fieldSource->getQuery()
         );
 
-    }
-
-    /** @test */
-    public function it_can_substitute_a_string_identifier_in_a_query()
-    {
-        $fieldSource = factory(FieldSource::class)->make([
-            'query' => "SELECT gender from PATIENT where id = sid"
-        ]);
-
-        $this->assertEquals(
-            "SELECT gender from PATIENT where id = '12345678'",
-            $fieldSource->getQueryFor("12345678")
-        );
     }
 
 

--- a/tests/Unit/SQLServerConnectionTest.php
+++ b/tests/Unit/SQLServerConnectionTest.php
@@ -39,14 +39,15 @@ class SQLServerConnectionTest extends TestCase
         $this->setUpDatabaseSource([
             'server' => '127.0.0.1',
             'port' => 999
-        ], "SELECT * FROM TEST_TABLE;");
+        ], "SELECT fakecolumn FROM TEST_TABLE WHERE id = ?");
 
-        $fakeId = '12345';
+        $fakeId = 12345;
 
         DB::shouldReceive('connection')->andReturn($this->connection);
-        $this->connection->shouldReceive('select')->with('SELECT * FROM TEST_TABLE;')
+
+        $this->connection->shouldReceive('select')->with('SELECT fakecolumn FROM TEST_TABLE WHERE id = ?', [$fakeId])
             ->andReturn([
-                    (object)['fakecolumn' => '12345']
+                    (object)['fakecolumn' => 12345]
                 ]
             );
 
@@ -63,13 +64,13 @@ class SQLServerConnectionTest extends TestCase
         $this->setUpDatabaseSource([
             'server' => '127.0.0.1',
             'port' => 999
-        ], "SELECT * FROM TEST_TABLE;");
+        ], "SELECT fakecolumn FROM TEST_TABLE WHERE id = ?");
 
-        $fakeId = '12345';
+        $fakeId = 12345;
 
         DB::shouldReceive('connection')->andReturn($this->connection);
 
-        $this->connection->shouldReceive('select')->with('SELECT * FROM TEST_TABLE;')
+        $this->connection->shouldReceive('select')->with('SELECT fakecolumn FROM TEST_TABLE WHERE id = ?', [$fakeId])
             ->andThrow(new \Exception('A BAD THING HAPPENED!'));
 
         $sqlServerConnection = new SQLServerConnection($this->databaseSource, $this->fieldSource);


### PR DESCRIPTION
**Because:** 

- Running raw SQL queries can lead to vulnerabilities re:SQL injection.

**This PR:**

- Alters query execution slightly to leverage Laravel parameter binding: https://laravel.com/docs/5.8/database#running-queries 