### PR TITLE
Add exception handling to throw graceful errors from server

### DIFF
--- a/app/DataRetrieval/Database/DatabaseConnectionBase.php
+++ b/app/DataRetrieval/Database/DatabaseConnectionBase.php
@@ -7,6 +7,7 @@ use App\DatabaseSource;
 use App\FieldSource;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use App\Exceptions\DatabaseConnectionException;
 
 abstract class DatabaseConnectionBase implements DatabaseConnection
 {
@@ -33,6 +34,7 @@ abstract class DatabaseConnectionBase implements DatabaseConnection
         } catch (\Exception $e)
         {
             Log::error($e->getMessage());
+            throw new DatabaseConnectionException("There was an issue connecting to the database.");
         }
 
         return false;


### PR DESCRIPTION
Added extra exception handling, which are caught and thrown as graceful 500 responses with an error object detailing what happened (without exposing sensitive data). Also includes relevant unit tests.